### PR TITLE
Set default frontend dev to point to the staging api

### DIFF
--- a/config/utils/envVars.js
+++ b/config/utils/envVars.js
@@ -2,10 +2,15 @@ const isGitHubDeploy = process.env.NOW_GITHUB_DEPLOYMENT == 1;
 
 const env = {
   development: {
-    TARTEEL_API_KEY: 'be5f3eaa01c226b0faa570e5a92ddca33ab51052',
-    RECOGNITION_SERVER_URL: 'http://localhost:5000',
-    TRANSCRIBE_SERVER_URL: 'http://localhost:5000',
-    API_URL: 'http://localhost:8000',
+    // Uncomment the following to use our backend services locally
+    // TARTEEL_API_KEY: 'be5f3eaa01c226b0faa570e5a92ddca33ab51052',
+    // RECOGNITION_SERVER_URL: 'http://localhost:5000',
+    // TRANSCRIBE_SERVER_URL: 'http://localhost:5000',
+    // API_URL: 'http://localhost:8000',
+    TARTEEL_API_KEY: process.env.STAGING_TARTEEL_API_KEY,
+    RECOGNITION_SERVER_URL: process.env.STAGING_RECOGNITION_SERVER_URL,
+    TRANSCRIBE_SERVER_URL: process.env.STAGING_TRANSCRIBE_SERVER_URL,
+    API_URL: process.env.STAGING_API_URL,
   },
   staging: {
     TARTEEL_API_KEY: process.env.STAGING_TARTEEL_API_KEY,


### PR DESCRIPTION
Update the dev frontend dev environment to point to staging by default. Makes it easier to get up & running w/o setting up the backend environment